### PR TITLE
nix: remove incorrect meta.mainProgram

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -36,6 +36,5 @@ stdenv.mkDerivation {
     description = "Qt6 theme provider for Hyprland";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.linux;
-    mainProgram = "hyprlock";
   };
 }


### PR DESCRIPTION
Looks like copy-pasta from hyprlock repo.